### PR TITLE
fix: address info parsing default value

### DIFF
--- a/includes/wp-affinidi-login-admin-settings.php
+++ b/includes/wp-affinidi-login-admin-settings.php
@@ -106,7 +106,7 @@ class Affinidi_Login_Admin_Settings
                             <li>Copy the <strong>Client ID</strong> and <strong>Issuer URL</strong> and paste it in Step 2 below.</li>
                             <li>
                                 <p>Modify the <strong>Presentation Definition</strong> and <strong>ID Token Mapping</strong> using <a href="https://docs.affinidi.com/labs/3rd-party-plugins/passwordless-authentication-for-wordpress/#presentation-definition-and-id-token-mapping" target="_blank">this template.</a></p>
-                                <p><em>If you have activated a supported E-Commerce plugin on this WordPress site, use the template for E-Commerce.', 'affinid-login'); ?></em></p>
+                                <p><em>If you have activated a supported E-Commerce plugin on this WordPress site, use the template for E-Commerce.</em></p>
                             </li>
                         </ol>
                     </div>

--- a/includes/wp-affinidi-login-idtoken.php
+++ b/includes/wp-affinidi-login-idtoken.php
@@ -40,13 +40,27 @@ class Affinidi_Login_IDToken {
     {
         // get list of countries for transformation
         include_once(AFFINIDI_PLUGIN_DIR . '/templates/countries-list.php');
+        // extract phone number from top level
+        $phoneNumber = $this->extract_claim($info, 'phone_number');
+        // do we have the address info 
+        if (!isset($info['address'])) {
+            // return empty
+            return array(
+                'address_1' => '',
+                'city' => '',
+                'state' => '',
+                'postcode' => '',
+                'country' => '',
+                'phone' => $phoneNumber
+            );
+        }
+
         // extract user info
         $streetAddress = $this->extract_claim($info['address'], 'street_address');
         $locality = $this->extract_claim($info['address'], 'locality');
         $region = $this->extract_claim($info['address'], 'region');
         $postalCode = $this->extract_claim($info['address'], 'postal_code');
         $country = $this->extract_claim($info['address'], 'country');
-        $phoneNumber = $this->extract_claim($info, 'phone_number');
     
         // get the country code
         $country = sanitize_text_field(array_search($country, $countries_list));

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: authentication, passwordless, multi-factor, sso, ecommerce
 Requires at least: 6.4
 Tested up to: 6.5
 Requires PHP: 7.4
-Stable tag: 1.1.1
+Stable tag: 1.1.2
 License: MIT
 License URI: https://github.com/affinidi/wordpress-affinidi-login/blob/main/LICENSE
 

--- a/wp-affinidi-login.php
+++ b/wp-affinidi-login.php
@@ -18,7 +18,7 @@
  * Plugin Name:       Affinidi Login - Passwordless Authentication
  * Plugin URI:        https://github.com/affinidi/wordpress-affinidi-login
  * Description:       A paradigm shift in the registration and sign-in process, Affinidi Login is a game-changing solution for developers. With our revolutionary passwordless authentication solution your user's first sign-in doubles as their registration, and all the necessary data for onboarding can be requested during this streamlined sign-in/signup process. End users are in full control, ensuring that they consent to the information shared in a transparent and user-friendly manner. This streamlined approach empowers developers to create efficient user experiences with data integrity, enhanced security and privacy, and ensures compatibility with industry standards.
- * Version:           1.1.1
+ * Version:           1.1.2
  * Requires at least: 6.4
  * Tested up to:      6.5
  * Requires PHP:      7.4


### PR DESCRIPTION
Updated:

- Fixed address info parsing and checked if the address claim was present. Return empty address by default.
- Removed extra text on admin settings.